### PR TITLE
JarLoadingActor Failure Message Fix

### DIFF
--- a/project/HyppoWorker.scala
+++ b/project/HyppoWorker.scala
@@ -3,10 +3,10 @@ import sbt._
 
 object HyppoWorker {
   //  This is the version of the canonical source-api that all components will be built against
-  final val ApiVersion    = "0.6.4"
+  val ApiVersion    = "0.6.4"
 
   //  This is the version that all components will share when published
-  final val WorkerVersion = "0.7.5-SNAPSHOT"
+  val WorkerVersion = "0.7.5"
 
   lazy val universalSettings = Seq(
     organization := "com.harrys.hyppo",

--- a/project/HyppoWorker.scala
+++ b/project/HyppoWorker.scala
@@ -6,7 +6,7 @@ object HyppoWorker {
   final val ApiVersion    = "0.6.4"
 
   //  This is the version that all components will share when published
-  final val WorkerVersion = "0.7.4"
+  final val WorkerVersion = "0.7.5-SNAPSHOT"
 
   lazy val universalSettings = Seq(
     organization := "com.harrys.hyppo",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.13

--- a/worker/src/main/scala/com/harrys/hyppo/worker/data/JarLoadingActor.scala
+++ b/worker/src/main/scala/com/harrys/hyppo/worker/data/JarLoadingActor.scala
@@ -3,17 +3,17 @@ package com.harrys.hyppo.worker.data
 import javax.inject.Inject
 
 import akka.actor.{Actor, ActorLogging, ActorRef}
-import akka.pattern.pipe
 import com.harrys.hyppo.worker.api.proto.RemoteStorageLocation
 
 import scala.concurrent.Future
+import scala.util.{Failure, Success}
 
 final class JarLoadingActor @Inject() (factory: JarFileLoader.Factory) extends Actor with ActorLogging {
   import JarLoadingActor._
   //  Load the dispatcher as the default execution context
   import context.dispatcher
 
-  val loader = factory(context.dispatcher)
+  val loader: JarFileLoader = factory(context.dispatcher)
 
   override def postStop(): Unit = {
     loader.shutdown()
@@ -28,11 +28,17 @@ final class JarLoadingActor @Inject() (factory: JarFileLoader.Factory) extends A
   def loadJarFiles(jarFiles: Seq[RemoteStorageLocation], recipient: ActorRef) : Unit = {
     val downloads = jarFiles.map(jar => loader.loadJarFile(jar))
     val combined  = Future.sequence(downloads).map(jars => JarsResult(jars))
-    combined.pipeTo(recipient)
+    combined.onComplete {
+      case Success(result) =>
+        recipient ! result
+      case f @ Failure(c) =>
+        log.warning(s"Failed to download jars from ${jarFiles.mkString(", ")}", c)
+        recipient ! f
+    }
   }
 }
 
 object JarLoadingActor {
-  case class LoadJars(jars: Seq[RemoteStorageLocation])
-  case class JarsResult(jars: Seq[LoadedJarFile])
+  final case class LoadJars(jars: Seq[RemoteStorageLocation])
+  final case class JarsResult(jars: Seq[LoadedJarFile])
 }


### PR DESCRIPTION
Fixed the JarLoadingActor to use scala.util.Failure instead of akka.util.Status.Failure when loading of the jar files fails